### PR TITLE
RT-714 Change for standalone upload service

### DIFF
--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -201,13 +201,14 @@ static void options(int *argc, char ***argv) {
 		die("Invalid 'output-storage' option");
 }
 
+int launch_upload_service() {
+
+}
 
 int main(int argc, char **argv) {
-	char tmp[512];
 	options(&argc, &argv);
-	snprintf(tmp, sizeof(tmp), "mkdir %s/upload", output_dir);
-	system(tmp);
 	setup();
+	launch_upload_service();
 	daemonize();
 	wpidfile();
 

--- a/recording-daemon/main.c
+++ b/recording-daemon/main.c
@@ -203,7 +203,10 @@ static void options(int *argc, char ***argv) {
 
 
 int main(int argc, char **argv) {
+	char tmp[512];
 	options(&argc, &argv);
+	snprintf(tmp, sizeof(tmp), "mkdir %s/upload", output_dir);
+	system(tmp);
 	setup();
 	daemonize();
 	wpidfile();

--- a/recording-daemon/output.c
+++ b/recording-daemon/output.c
@@ -166,11 +166,11 @@ void output_close(output_t *output) {
 	char suff[16] = "";
 	if (!output)
 		return;
-	ilog(LOG_ERR, "!!!!! output_close: %s", output->full_filename);
+	//ilog(LOG_ERR, "!!!!! output_close: %s", output->full_filename);
 	if (output->file_suff > 0)
 		snprintf(suff, sizeof(suff), "-%i", output->file_suff);
 	snprintf(cmd, sizeof(cmd), "mv %s%s.%s %s/upload", output->full_filename, suff, output->file_format, output_dir);		
-	ilog(LOG_ERR, "!!!!! exec cmd: %s", cmd);
+	dbg("!!!!! move the recorded file to upload folder: %s", cmd);
 	output_shutdown(output);
 	db_close_stream(output);
 	encoder_free(output->encoder);

--- a/recording-daemon/output.c
+++ b/recording-daemon/output.c
@@ -1,12 +1,14 @@
 #include "output.h"
 #include <libavcodec/avcodec.h>
 #include <limits.h>
+#include <unistd.h>
 #include <string.h>
 #include <stdint.h>
 #include <glib.h>
 #include "log.h"
 #include "db.h"
 
+extern const char *output_dir;
 
 //static int output_codec_id;
 static const codec_def_t *output_codec;
@@ -48,6 +50,7 @@ output_t *output_new(const char *path, const char *filename) {
 	g_strlcpy(ret->file_path, path, sizeof(ret->file_path));
 	g_strlcpy(ret->file_name, filename, sizeof(ret->file_name));
 	snprintf(ret->full_filename, sizeof(ret->full_filename), "%s/%s", path, filename);
+	ret->file_suff = 0;
 	ret->file_format = output_file_format;
 	ret->encoder = encoder_new();
 	return ret;
@@ -104,6 +107,7 @@ int output_config(output_t *output, const format_t *requested_format, format_t *
 		snprintf(full_fn, sizeof(full_fn), "%s%s.%s", output->full_filename, suff, output->file_format);
 		if (!g_file_test(full_fn, G_FILE_TEST_EXISTS))
 			goto got_fn;
+		output->file_suff = i;
 		snprintf(suff, sizeof(suff), "-%i", i);
 	}
 
@@ -158,12 +162,20 @@ static void output_shutdown(output_t *output) {
 
 
 void output_close(output_t *output) {
+	char cmd[PATH_MAX*3];
+	char suff[16] = "";
 	if (!output)
 		return;
+	ilog(LOG_ERR, "!!!!! output_close: %s", output->full_filename);
+	if (output->file_suff > 0)
+		snprintf(suff, sizeof(suff), "-%i", output->file_suff);
+	snprintf(cmd, sizeof(cmd), "mv %s%s.%s %s/upload", output->full_filename, suff, output->file_format, output_dir);		
+	ilog(LOG_ERR, "!!!!! exec cmd: %s", cmd);
 	output_shutdown(output);
 	db_close_stream(output);
 	encoder_free(output->encoder);
 	g_slice_free1(sizeof(*output), output);
+	system(cmd);
 }
 
 

--- a/recording-daemon/types.h
+++ b/recording-daemon/types.h
@@ -140,6 +140,7 @@ struct output_s {
 	char full_filename[PATH_MAX], // path + filename
 		file_path[PATH_MAX],
 		file_name[PATH_MAX];
+	int file_suff;
 	const char *file_format;
 	unsigned long long db_id;
 


### PR DESCRIPTION
1. Move the recorded spx file to /var/lib/rtpengine/upload where the upload service will pick it up from
2. Suffix spx filename with connectionUid so even the call has been ended and no mapping in Redis, we could still upload this spx file to S3 without any problem.