### PR TITLE
RT738 : Move the connect to sub thread to fix the ffmpeg blocking error

### DIFF
--- a/recording-daemon/ahclient/ahclient.c
+++ b/recording-daemon/ahclient/ahclient.c
@@ -126,7 +126,7 @@ void destroy_ahclient(void) {
 
 socket_handler_t create_ah_connection(void){
 
-    socket_handler_t handler = INVALIUD_SOCKET_HANDLER;
+    socket_handler_t handler = INVALID_SOCKET_HANDLER;
 
     pthread_mutex_lock(&ahclient_instance->ah_check_mutex);
     time_t current_time = time(NULL);
@@ -136,11 +136,11 @@ socket_handler_t create_ah_connection(void){
         if (handler < 0 ) {
             ilog(LOG_ERROR,"Couldn't create a socket handler for ah client: %d:%s.", errno, strerror(errno));
             time(&ahclient_instance->ah_last_disconnect_ts);    // Update last disconnect time
-            handler = INVALIUD_SOCKET_HANDLER;
+            handler = INVALID_SOCKET_HANDLER;
         } else  if (connect(handler, &(ahclient_instance->ah_server_address), sizeof(sockaddr_in_t)) < 0) {
             ilog(LOG_ERROR," Couldn't create a socket connection for ah client errno: %d : %s", errno, strerror(errno));
             close(handler);
-            handler = INVALIUD_SOCKET_HANDLER;
+            handler = INVALID_SOCKET_HANDLER;
             time(&ahclient_instance->ah_last_disconnect_ts);    // Update last disconnect time
         } else {
             ilog(LOG_INFO, "ah server server connected.");

--- a/recording-daemon/ahclient/ahclient.c
+++ b/recording-daemon/ahclient/ahclient.c
@@ -204,11 +204,11 @@ void ahclient_post_stream(const metafile_t * metafile, int id, const unsigned ch
 void * async_close_channel(void * arg) 
 {
     channel_node_t * channel_node = (channel_node_t *)arg;
-
+   
     // safe delete channel
-    delete_ahclient_mux_channel(channel_node->channel);
+    delete_ahclient_mux_channel(channel_node->channel);       
     free(channel_node);
-
+    
     return NULL;
 }
 
@@ -240,7 +240,9 @@ void ahclient_close_stream(const metafile_t * metafile, int id) {
                 }
                 // delete current node
                 ahclient_instance->channel_count--;
-   
+                char uid[UIDLEN + 1];
+                ilog(LOG_INFO, "[total channel left: %d] Closing channel for Call [%s] ",ahclient_instance->channel_count, show_UID(metafile->call_id, uid));
+               
                 // RT-738 : asynchronous mode to close a channel
                 pthread_t thread_id;
                 pthread_create(&thread_id , NULL, &async_close_channel, (void *)channel_node);

--- a/recording-daemon/ahclient/ahclient.c
+++ b/recording-daemon/ahclient/ahclient.c
@@ -40,59 +40,30 @@ ahclient_t * ahclient_instance = NULL;
 const int  STREAM_ID_L_RTP = 0;
 const int  STREAM_ID_R_RTP = 2;
 
-BOOL server_port_accessible(char * ah_ip, unsigned int ah_port) {
-
-    char cmd [100] = {0};
-    // nc -av <ip> <port>
-    sprintf(cmd,"nc -zv %s %d 2>&1", ah_ip, ah_port);
-    FILE* fp = popen(cmd, "r");
-
-    BOOL ret = FALSE;
-    if ( fp == NULL ) {
-        ilog(LOG_ERROR,"Failed to run system command %s .", cmd);
-        ret = FALSE;
-    } else {
-        char line[256]={0};
-
-        while (fgets(line, sizeof(line)-1, fp) != NULL) {
-            ilog(LOG_INFO,"%s", line);
-            if (strstr(line, "Connected to") != NULL) { // connected
-                ret = TRUE;
-                break;
-            }
-        }
-        pclose(fp);
-    }
-    return ret;
-}
 
 // WARN : it's not a thread safe singleton, should not be called from multiple threads
 void init_ahclient(char * ah_ip, unsigned int ah_port, BOOL transcribe_all){
     ilog(LOG_INFO, "init_ahclient : %s:%d transcribe_all = %d", ah_ip, ah_port, transcribe_all);
 
     if (ahclient_instance == NULL) {
-        if (server_port_accessible (ah_ip, ah_port)) {
-            // Create instance
-            ahclient_instance = (ahclient_t *)malloc(sizeof( ahclient_t));
+        // Create instance
+        ahclient_instance = (ahclient_t *)malloc(sizeof( ahclient_t));
 
-            ahclient_instance->ah_last_disconnect_ts = 0;
-            pthread_mutex_init(&(ahclient_instance->ah_check_mutex), NULL);
+        ahclient_instance->ah_last_disconnect_ts = 0;
+        pthread_mutex_init(&(ahclient_instance->ah_check_mutex), NULL);
 
-            // Init AH server address
-            ahclient_instance->ah_server_address.sin_addr.s_addr = inet_addr(ah_ip);
-            ahclient_instance->ah_server_address.sin_port = htons(ah_port);
-            ahclient_instance->ah_server_address.sin_family = AF_INET;
+        // Init AH server address
+        ahclient_instance->ah_server_address.sin_addr.s_addr = inet_addr(ah_ip);
+        ahclient_instance->ah_server_address.sin_port = htons(ah_port);
+        ahclient_instance->ah_server_address.sin_family = AF_INET;
 
-            // Init channels linklist to NULL
-            ahclient_instance->channels = NULL;
-            ahclient_instance->channel_count = 0;
-            ahclient_instance->transcribe_all = transcribe_all;
+        // Init channels linklist to NULL
+        ahclient_instance->channels = NULL;
+        ahclient_instance->channel_count = 0;
+        ahclient_instance->transcribe_all = transcribe_all;
 
-            // init Mutex
-            pthread_mutex_init(&(ahclient_instance->channels_mutex), NULL);
-        } else {
-            ilog(LOG_ERROR,"AH server [%s:%d] is unaccessible, please check your configuration.", ah_ip, ah_port);
-        }
+        // init Mutex
+        pthread_mutex_init(&(ahclient_instance->channels_mutex), NULL);
     }
 }
 

--- a/recording-daemon/ahclient/ahclient.h
+++ b/recording-daemon/ahclient/ahclient.h
@@ -26,7 +26,7 @@ typedef unsigned int BOOL;
 #endif
 
 typedef int socket_handler_t;
-#define INVALIUD_SOCKET_HANDLER   (-1)
+#define INVALID_SOCKET_HANDLER   (-1)
 
 void init_ahclient(char * ah_ip, unsigned int ah_port, BOOL transcribe_all);
 void destroy_ahclient(void);

--- a/recording-daemon/ahclient/ahclient.h
+++ b/recording-daemon/ahclient/ahclient.h
@@ -26,6 +26,7 @@ typedef unsigned int BOOL;
 #endif
 
 typedef int socket_handler_t;
+#define INVALIUD_SOCKET_HANDLER   (-1)
 
 void init_ahclient(char * ah_ip, unsigned int ah_port, BOOL transcribe_all);
 void destroy_ahclient(void);

--- a/recording-daemon/ahclient/ahclientchannel.c
+++ b/recording-daemon/ahclient/ahclientchannel.c
@@ -279,9 +279,8 @@ void ahchannel_sent_stream(ahclient_mux_channel_t *  channel, BOOL flush)
 void * ahclient_mux_channel_sending_thread(void * arg)
 {
     ahclient_mux_channel_t * channel = (ahclient_mux_channel_t * )arg;
-
+    channel->socket_handler = create_ah_connection();   // Create a connection for this thread
     while(1) {
-
         sem_wait(&channel->thread_sem); 
         ahchannel_sent_stream(channel, channel->close_channel);
         if (channel->close_channel) {
@@ -321,8 +320,8 @@ ahclient_mux_channel_t * new_ahclient_mux_channel(const metafile_t * metafile)
     init_audio_strem_header_t(&instance->stream_header, metafile);
 
     // init socket connection
-    instance->socket_handler = create_ah_connection();
-
+    instance->socket_handler = INVALIUD_SOCKET_HANDLER;  // will be created in child thread
+ 
     // start child thread
     pthread_create(&instance->sub_subthread , NULL, &ahclient_mux_channel_sending_thread, (void *)instance);
 

--- a/recording-daemon/ahclient/ahclientchannel.c
+++ b/recording-daemon/ahclient/ahclientchannel.c
@@ -216,7 +216,7 @@ void ahchannel_sent_stream(ahclient_mux_channel_t *  channel, BOOL flush)
         if ( send_buf == NULL ) send_buf = gen_mux_buffer(channel, flush, &buf_size);
         if ( send_buf == NULL)  break;   // nothing to sent
 
-        if (channel->socket_handler != INVALIUD_SOCKET_HANDLER) {
+        if (channel->socket_handler != INVALID_SOCKET_HANDLER) {
             BOOL sent = (-1 != send(channel->socket_handler, 
                                 send_buf, 
                                 buf_size, 0));
@@ -235,7 +235,7 @@ void ahchannel_sent_stream(ahclient_mux_channel_t *  channel, BOOL flush)
                 if ( resend_count == SOCKET_RESENT_MAX_RETRY) {
                     // shutdown connection, discard the unsent data and time-outed ACK
                     shutdown(channel->socket_handler, 2);
-                    channel->socket_handler = INVALIUD_SOCKET_HANDLER;  // Will be reconnet
+                    channel->socket_handler = INVALID_SOCKET_HANDLER;  // Will be reconnet
                     resend_count = 0;
                     // If it's not flush, we can try to re-connect in next semaphore
                     if (!flush) break;
@@ -247,7 +247,7 @@ void ahchannel_sent_stream(ahclient_mux_channel_t *  channel, BOOL flush)
         } else {
             reconnect_count++;
             channel->socket_handler = create_ah_connection();       
-            if (channel->socket_handler  == INVALIUD_SOCKET_HANDLER )  {
+            if (channel->socket_handler  == INVALID_SOCKET_HANDLER )  {
                 if (flush && reconnect_count < SOCKET_RECONNECT_MAX_RETRY) {    //  this is the last semaphone, need to close the channel, we should wait and retry instead of waiting for the next semaphone
                     sleep(SOCKET_RECONNECT_WAIT_TIME_SECOND);
                     ilog(LOG_ERROR,"Re connect socket to AH client retry:%d", reconnect_count);
@@ -320,7 +320,7 @@ ahclient_mux_channel_t * new_ahclient_mux_channel(const metafile_t * metafile)
     init_audio_strem_header_t(&instance->stream_header, metafile);
 
     // init socket connection
-    instance->socket_handler = INVALIUD_SOCKET_HANDLER;  // will be created in child thread
+    instance->socket_handler = INVALID_SOCKET_HANDLER;  // will be created in child thread
  
     // start child thread
     pthread_create(&instance->sub_subthread , NULL, &ahclient_mux_channel_sending_thread, (void *)instance);
@@ -386,7 +386,7 @@ void delete_ahclient_mux_channel(ahclient_mux_channel_t *  instance)
         pthread_join(instance->sub_subthread, NULL);
 
         // close socket
-        if (instance->socket_handler != INVALIUD_SOCKET_HANDLER)
+        if (instance->socket_handler != INVALID_SOCKET_HANDLER)
             close(instance->socket_handler);
 
         // destroy semaphore

--- a/recording-daemon/ahclient/ahclientchannel.h
+++ b/recording-daemon/ahclient/ahclientchannel.h
@@ -64,6 +64,8 @@ typedef struct ahclient_mux_channel {
     unsent_buf_node_t * unsent_buf_head[CHANNEL_COUNT];
     unsent_buf_node_t * unsent_buf_tail[CHANNEL_COUNT];
     unsigned int        unsent_buf_size[CHANNEL_COUNT];
+    unsigned int        sem_posted_at;
+    unsigned int        steam_posted_size;
     BOOL                eof_flag[CHANNEL_COUNT];
 
     unsigned int    retry_buf_len;

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -67,6 +67,9 @@ static void stream_handler(handler_t *handler) {
 			goto out;
 		ilog(LOG_INFO, "Read error on stream %s: %s", stream->name, strerror(errno));
 		stream_close(stream);
+#if  _WITH_AH_CLIENT
+		ahclient_close_stream(stream->metafile, stream->id);
+#endif
 		goto out;
 	}
 


### PR DESCRIPTION
1. check the AH server's availability before create the client  (new function server_port_accessible())
2. add a 10 second waiting time for reconnect since last  connection failed (Otherwise each thread will try to reconnect upon semaphore posted)  (in function create_ah_connection(void))
3. Add a 3 seconds waiting time for resent.  (in function ahchannel_sent_stream())
4. Simplify the semaphore posting logic. When disconnected, before was posting one semaphore on every packet (0.02s), now will reduce to about one seconds (in funtction ahchannel_post_stream())
5. Make close channel a async function call (A new function call async_close_channel() from ahclient_close_stream())
6. Some minor change
