### PR TITLE
RT-1016 Adding connection information to logs

### DIFF
--- a/recording-daemon/metafile.c
+++ b/recording-daemon/metafile.c
@@ -121,7 +121,7 @@ static void meta_stream_interface(metafile_t *mf, unsigned long snum, char *cont
 
 			snprintf(buf, sizeof(buf), "%s-%s-mix", mf->parent, connectionUid);
 			mf->mix_out = output_new(output_dir, buf);
-			mf->mix = mix_new();
+			mf->mix = mix_new(mf);
 			db_do_stream(mf, mf->mix_out, "mixed", NULL, 0);
 		}
 		pthread_mutex_unlock(&mf->mix_lock);

--- a/recording-daemon/mix.c
+++ b/recording-daemon/mix.c
@@ -225,8 +225,8 @@ static void log_repeated_error(int err_count, const char* err, int ret, const ch
 		if (err_count == 1)
 			ilog(LOG_ERR, "[%s] Failure in max_add: %s(ret=%d, err=%s)",call_id, err, ret, errmsg);
 		else 
-			ilog(LOG_ERR, "Failure in max_add: %s (ret=%d, err=%s, happened %d times in last %d seconds)", 
-						err, ret, errmsg, err_count, MIX_TIMER_INTERVAL);
+			ilog(LOG_ERR, "[%s] Failure in max_add: %s (ret=%d, err=%s, happened %d times in last %d seconds)", 
+						call_id, err, ret, errmsg, err_count, MIX_TIMER_INTERVAL);
 	}
 }
 

--- a/recording-daemon/mix.h
+++ b/recording-daemon/mix.h
@@ -5,7 +5,7 @@
 #include <libavutil/frame.h>
 
 
-mix_t *mix_new(void);
+mix_t *mix_new(metafile_t *);
 void mix_destroy(mix_t *mix);
 
 int mix_get_out_channels(int input_channels);

--- a/recording-daemon/packet.c
+++ b/recording-daemon/packet.c
@@ -250,7 +250,7 @@ static void packet_decode(ssrc_t *ssrc, packet_t *packet) {
 		if (!payload_str) {
 			const struct rtp_payload_type *rpt = rtp_get_rfc_payload_type(payload_type);
 			if (!rpt) {
-				ilog(LOG_WARN, "Unknown RTP payload type %u", payload_type);
+				ilog(LOG_WARN, "[%s] Unknown RTP payload type %u",mf->call_id, payload_type);
 				return;
 			}
 			payload_str = rpt->encoding_with_params.s;

--- a/recording-daemon/stream.c
+++ b/recording-daemon/stream.c
@@ -55,7 +55,7 @@ static void stream_handler(handler_t *handler) {
 	int ret = read(stream->fd, buf, MAXBUFLEN);
 	
 	if (ret == 0) {
-		ilog(LOG_INFO, "EOF on stream %s", stream->name);
+		ilog(LOG_INFO, "[%s] EOF on stream %s",stream->metafile->call_id, stream->name);
 		stream_close(stream);
 #if  _WITH_AH_CLIENT
 		ahclient_close_stream(stream->metafile, stream->id);


### PR DESCRIPTION
This PR has the code changes to add the connection information for the logs where it was missing. 
Also I have provided explanation for the reason of duplication of logs.
Please find the details below

Sample 1 -  Fixed by adding metafile handle in the mix_t structure and then printing metafile.call_id

Sample 2 -  Fixed by print  metafile->call_id 

Sample 3-  It is confirmed that our code is not directly or indirectly printing it twice.  .  ffmpeg is printing twice once on console and once in logger callback. Since we have redirected console log file it appears to be printing twice. Hence duplication cannot  be fixed

Sample 4 -  Connection information cannot be added as the log is directly printed by ffmpeg where connection information is not available

Sample 5 -  Same explanation as sample 3. Here connection information is added.